### PR TITLE
feat: add support to ?format=json

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A lightweight, fast HTTP service for detecting client IP addresses with comprehe
 
 - 🌐 **Multi-Protocol Support**: Detects both IPv4 and IPv6 addresses
 - 🔍 **Comprehensive Header Analysis**: Supports all major proxy headers (Cloudflare, nginx, Apache, etc.)
-- 🏷️ **Multiple Output Formats**: Plain text, JSON, and detailed information endpoints
+- 🏷️ **Multiple Output Formats**: Plain text, JSON, and detailed information endpoints with query parameter support
 - 📚 **Interactive API Documentation**: Built-in Swagger UI with OpenAPI specification
 - 🛡️ **Security Focused**: Identifies private IPs, proxy chains, and Cloudflare detection
 - 🚀 **High Performance**: Lightweight Go implementation with minimal dependencies
@@ -49,7 +49,9 @@ Download the latest binary from the [releases page](https://github.com/akhfa/myi
 | Endpoint | Description | Response Type |
 |----------|-------------|---------------|
 | `/` | IPv4 address only | `text/plain` |
+| `/?format=json` | IPv4 address in JSON format | `application/json` |
 | `/ipv6` | IPv6 address only (404 if not available) | `text/plain` |
+| `/ipv6?format=json` | IPv6 address in JSON format | `application/json` |
 | `/info` | Detailed IP information | `text/plain` |
 | `/json` | Comprehensive JSON response | `application/json` |
 | `/headers` | All HTTP headers and IP details | `text/plain` |
@@ -72,10 +74,22 @@ $ curl https://ip.example.com/
 203.0.113.1
 ```
 
+#### Get IPv4 Address in JSON Format
+```bash
+$ curl https://ip.example.com/?format=json
+{"ip":"203.0.113.1"}
+```
+
 #### Get IPv6 Address
 ```bash
 $ curl https://ip.example.com/ipv6
 2001:db8::1
+```
+
+#### Get IPv6 Address in JSON Format
+```bash
+$ curl https://ip.example.com/ipv6?format=json
+{"ip":"2001:db8::1"}
 ```
 
 #### Get Detailed Information

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -5,11 +5,23 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 
 	"myip/internal/ip"
 	"myip/internal/models"
 )
+
+// isJSONFormat checks if format parameter equals "json" case-insensitively
+// Optimized for performance - avoids string allocation from ToLower()
+func isJSONFormat(format string) bool {
+	if len(format) != 4 {
+		return false
+	}
+	// Check each byte directly for maximum performance
+	return (format[0] == 'j' || format[0] == 'J') &&
+		(format[1] == 's' || format[1] == 'S') &&
+		(format[2] == 'o' || format[2] == 'O') &&
+		(format[3] == 'n' || format[3] == 'N')
+}
 
 // IPv4Handler handles requests for IPv4 addresses only
 // @Summary Get IPv4 address
@@ -30,9 +42,9 @@ func IPv4Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if JSON format is requested (case-insensitive)
+	// Check if JSON format is requested (case-insensitive, optimized)
 	format := r.URL.Query().Get("format")
-	if strings.ToLower(format) == "json" {
+	if isJSONFormat(format) {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]string{"ip": ipv4}
 		
@@ -68,9 +80,9 @@ func IPv6Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if JSON format is requested (case-insensitive)
+	// Check if JSON format is requested (case-insensitive, optimized)
 	format := r.URL.Query().Get("format")
-	if strings.ToLower(format) == "json" {
+	if isJSONFormat(format) {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]string{"ip": ipv6}
 		

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -47,7 +47,7 @@ func IPv4Handler(w http.ResponseWriter, r *http.Request) {
 	if isJSONFormat(format) {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]string{"ip": ipv4}
-		
+
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			log.Printf("Failed to encode JSON response for IPv4 %s: %v", ipv4, err)
 			http.Error(w, "Failed to encode JSON response", http.StatusInternalServerError)
@@ -85,7 +85,7 @@ func IPv6Handler(w http.ResponseWriter, r *http.Request) {
 	if isJSONFormat(format) {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]string{"ip": ipv6}
-		
+
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			log.Printf("Failed to encode JSON response for IPv6 %s: %v", ipv6, err)
 			http.Error(w, "Failed to encode JSON response", http.StatusInternalServerError)

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -11,11 +11,13 @@ import (
 
 // IPv4Handler handles requests for IPv4 addresses only
 // @Summary Get IPv4 address
-// @Description Returns the client's IPv4 address in plain text format
+// @Description Returns the client's IPv4 address in plain text format, or JSON format if format=json query parameter is specified
 // @Tags IP Detection
 // @Accept json
-// @Produce plain
-// @Success 200 {string} string "IPv4 address"
+// @Produce plain,json
+// @Param format query string false "Response format (json for JSON response)"
+// @Success 200 {string} string "IPv4 address (plain text)"
+// @Success 200 {object} map[string]string "IP address in JSON format: {\"ip\": \"192.168.1.1\"}"
 // @Failure 404 {string} string "No IPv4 address found"
 // @Router / [get]
 func IPv4Handler(w http.ResponseWriter, r *http.Request) {
@@ -26,17 +28,33 @@ func IPv4Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check if JSON format is requested
+	format := r.URL.Query().Get("format")
+	if format == "json" {
+		w.Header().Set("Content-Type", "application/json")
+		response := map[string]string{"ip": ipv4}
+		
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			http.Error(w, "Failed to encode JSON response", http.StatusInternalServerError)
+			return
+		}
+		return
+	}
+
+	// Default plain text response
 	w.Header().Set("Content-Type", "text/plain")
 	fmt.Fprint(w, ipv4)
 }
 
 // IPv6Handler handles requests for IPv6 addresses only
 // @Summary Get IPv6 address
-// @Description Returns the client's IPv6 address in plain text format
+// @Description Returns the client's IPv6 address in plain text format, or JSON format if format=json query parameter is specified
 // @Tags IP Detection
 // @Accept json
-// @Produce plain
-// @Success 200 {string} string "IPv6 address"
+// @Produce plain,json
+// @Param format query string false "Response format (json for JSON response)"
+// @Success 200 {string} string "IPv6 address (plain text)"
+// @Success 200 {object} map[string]string "IP address in JSON format: {\"ip\": \"2001:db8::1\"}"
 // @Failure 404 {string} string "No IPv6 address found"
 // @Router /ipv6 [get]
 func IPv6Handler(w http.ResponseWriter, r *http.Request) {
@@ -47,6 +65,20 @@ func IPv6Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check if JSON format is requested
+	format := r.URL.Query().Get("format")
+	if format == "json" {
+		w.Header().Set("Content-Type", "application/json")
+		response := map[string]string{"ip": ipv6}
+		
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			http.Error(w, "Failed to encode JSON response", http.StatusInternalServerError)
+			return
+		}
+		return
+	}
+
+	// Default plain text response
 	w.Header().Set("Content-Type", "text/plain")
 	fmt.Fprint(w, ipv6)
 }

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -3,7 +3,9 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"strings"
 
 	"myip/internal/ip"
 	"myip/internal/models"
@@ -11,7 +13,7 @@ import (
 
 // IPv4Handler handles requests for IPv4 addresses only
 // @Summary Get IPv4 address
-// @Description Returns the client's IPv4 address in plain text format, or JSON format if format=json query parameter is specified
+// @Description Returns the client's IPv4 address in plain text format, or JSON format if format=json query parameter is specified (case-insensitive)
 // @Tags IP Detection
 // @Accept json
 // @Produce plain,json
@@ -28,13 +30,14 @@ func IPv4Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if JSON format is requested
+	// Check if JSON format is requested (case-insensitive)
 	format := r.URL.Query().Get("format")
-	if format == "json" {
+	if strings.ToLower(format) == "json" {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]string{"ip": ipv4}
 		
 		if err := json.NewEncoder(w).Encode(response); err != nil {
+			log.Printf("Failed to encode JSON response for IPv4 %s: %v", ipv4, err)
 			http.Error(w, "Failed to encode JSON response", http.StatusInternalServerError)
 			return
 		}
@@ -48,7 +51,7 @@ func IPv4Handler(w http.ResponseWriter, r *http.Request) {
 
 // IPv6Handler handles requests for IPv6 addresses only
 // @Summary Get IPv6 address
-// @Description Returns the client's IPv6 address in plain text format, or JSON format if format=json query parameter is specified
+// @Description Returns the client's IPv6 address in plain text format, or JSON format if format=json query parameter is specified (case-insensitive)
 // @Tags IP Detection
 // @Accept json
 // @Produce plain,json
@@ -65,13 +68,14 @@ func IPv6Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if JSON format is requested
+	// Check if JSON format is requested (case-insensitive)
 	format := r.URL.Query().Get("format")
-	if format == "json" {
+	if strings.ToLower(format) == "json" {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]string{"ip": ipv6}
 		
 		if err := json.NewEncoder(w).Encode(response); err != nil {
+			log.Printf("Failed to encode JSON response for IPv6 %s: %v", ipv6, err)
 			http.Error(w, "Failed to encode JSON response", http.StatusInternalServerError)
 			return
 		}

--- a/internal/handlers/handlers_benchmark_test.go
+++ b/internal/handlers/handlers_benchmark_test.go
@@ -9,7 +9,7 @@ import (
 func BenchmarkIsJSONFormat(b *testing.B) {
 	testCases := []string{
 		"json",
-		"JSON", 
+		"JSON",
 		"Json",
 		"jSoN",
 		"xml",
@@ -17,7 +17,7 @@ func BenchmarkIsJSONFormat(b *testing.B) {
 		"",
 		"jsonformat", // longer string
 	}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, format := range testCases {
@@ -30,7 +30,7 @@ func BenchmarkIsJSONFormat(b *testing.B) {
 func BenchmarkStringToLower(b *testing.B) {
 	testCases := []string{
 		"json",
-		"JSON", 
+		"JSON",
 		"Json",
 		"jSoN",
 		"xml",
@@ -38,7 +38,7 @@ func BenchmarkStringToLower(b *testing.B) {
 		"",
 		"jsonformat", // longer string
 	}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, format := range testCases {
@@ -50,7 +50,7 @@ func BenchmarkStringToLower(b *testing.B) {
 // BenchmarkHandlerJSONCheck benchmarks the format check in context
 func BenchmarkHandlerJSONCheck(b *testing.B) {
 	formats := []string{"json", "JSON", "Json", "xml", ""}
-	
+
 	b.Run("Optimized", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -59,7 +59,7 @@ func BenchmarkHandlerJSONCheck(b *testing.B) {
 			}
 		}
 	})
-	
+
 	b.Run("StringsToLower", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/internal/handlers/handlers_benchmark_test.go
+++ b/internal/handlers/handlers_benchmark_test.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+// BenchmarkIsJSONFormat benchmarks our optimized case-insensitive comparison
+func BenchmarkIsJSONFormat(b *testing.B) {
+	testCases := []string{
+		"json",
+		"JSON", 
+		"Json",
+		"jSoN",
+		"xml",
+		"text",
+		"",
+		"jsonformat", // longer string
+	}
+	
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, format := range testCases {
+			_ = isJSONFormat(format)
+		}
+	}
+}
+
+// BenchmarkStringToLower benchmarks the strings.ToLower approach
+func BenchmarkStringToLower(b *testing.B) {
+	testCases := []string{
+		"json",
+		"JSON", 
+		"Json",
+		"jSoN",
+		"xml",
+		"text",
+		"",
+		"jsonformat", // longer string
+	}
+	
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, format := range testCases {
+			_ = strings.ToLower(format) == "json"
+		}
+	}
+}
+
+// BenchmarkHandlerJSONCheck benchmarks the format check in context
+func BenchmarkHandlerJSONCheck(b *testing.B) {
+	formats := []string{"json", "JSON", "Json", "xml", ""}
+	
+	b.Run("Optimized", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, format := range formats {
+				_ = isJSONFormat(format)
+			}
+		}
+	})
+	
+	b.Run("StringsToLower", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, format := range formats {
+				_ = strings.ToLower(format) == "json"
+			}
+		}
+	})
+}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -494,6 +494,26 @@ func TestIPv4HandlerJSONFormat(t *testing.T) {
 			expectJSON:   false,
 		},
 		{
+			name:  "JSON format requested - uppercase",
+			query: "?format=JSON",
+			headers: map[string]string{
+				"CF-Connecting-IP": "203.0.113.1",
+			},
+			remoteAddr:   "192.168.1.1:12345",
+			expectedCode: http.StatusOK,
+			expectJSON:   true,
+		},
+		{
+			name:  "JSON format requested - mixed case",
+			query: "?format=Json",
+			headers: map[string]string{
+				"CF-Connecting-IP": "203.0.113.1",
+			},
+			remoteAddr:   "192.168.1.1:12345",
+			expectedCode: http.StatusOK,
+			expectJSON:   true,
+		},
+		{
 			name:  "Other format parameter ignored",
 			query: "?format=xml",
 			headers: map[string]string{
@@ -585,6 +605,26 @@ func TestIPv6HandlerJSONFormat(t *testing.T) {
 			remoteAddr:   "[2001:db8::1]:12345",
 			expectedCode: http.StatusOK,
 			expectJSON:   false,
+		},
+		{
+			name:  "JSON format requested with IPv6 - uppercase",
+			query: "?format=JSON",
+			headers: map[string]string{
+				"CF-Connecting-IP": "2001:db8::1",
+			},
+			remoteAddr:   "[2001:db8::1]:12345",
+			expectedCode: http.StatusOK,
+			expectJSON:   true,
+		},
+		{
+			name:  "JSON format requested with IPv6 - mixed case",
+			query: "?format=Json",
+			headers: map[string]string{
+				"CF-Connecting-IP": "2001:db8::1",
+			},
+			remoteAddr:   "[2001:db8::1]:12345",
+			expectedCode: http.StatusOK,
+			expectJSON:   true,
 		},
 	}
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add JSON response format support via `format=json` query parameter

- Implement comprehensive test coverage for JSON format functionality

- Update API documentation to reflect new JSON format option


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP Request"] -- "?format=json" --> B{Query Parameter Check}
  B -- "format=json" --> C["JSON Response"]
  B -- "Other format" --> D["Plain Text Response"]
  C --> E["application/json Content-Type"]
  D --> F["text/plain Content-Type"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handlers.go</strong><dd><code>Add JSON format query parameter support to IP handlers</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/handlers/handlers.go

<ul><li>Added query parameter parsing for <code>format=json</code> support<br> <li> Implemented JSON response encoding with proper error handling<br> <li> Updated Swagger annotations to document new JSON format option<br> <li> Maintained backward compatibility with plain text responses</ul>


</details>


  </td>
  <td><a href="https://github.com/akhfa/myip/pull/23/files#diff-0043929b176a6dd563ab4f5b393f095138a1200b3a22647ca5aa8e112579c80a">+38/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handlers_test.go</strong><dd><code>Add extensive test coverage for JSON format feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/handlers/handlers_test.go

<ul><li>Added comprehensive test cases for JSON format functionality<br> <li> Test both IPv4 and IPv6 handlers with various format scenarios<br> <li> Validate JSON response structure and content type headers<br> <li> Ensure proper fallback to plain text for invalid formats</ul>


</details>


  </td>
  <td><a href="https://github.com/akhfa/myip/pull/23/files#diff-ef220a63cc346acf15844229fdca3197371fc38b594b993251e191b47ff6d7ed">+176/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation with JSON format usage examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated endpoint documentation to include JSON format examples<br> <li> Added new curl command examples showing JSON responses<br> <li> Enhanced feature list to mention query parameter support</ul>


</details>


  </td>
  <td><a href="https://github.com/akhfa/myip/pull/23/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

