### PR TITLE
feat: added feature for jsonp and callback query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A lightweight, fast HTTP service for detecting client IP addresses with comprehe
 
 - 🌐 **Multi-Protocol Support**: Detects both IPv4 and IPv6 addresses
 - 🔍 **Comprehensive Header Analysis**: Supports all major proxy headers (Cloudflare, nginx, Apache, etc.)
-- 🏷️ **Multiple Output Formats**: Plain text, JSON, and detailed information endpoints with query parameter support
+- 🏷️ **Multiple Output Formats**: Plain text, JSON, and JSONP endpoints with flexible query parameter support
 - 📚 **Interactive API Documentation**: Built-in Swagger UI with OpenAPI specification
 - 🛡️ **Security Focused**: Identifies private IPs, proxy chains, and Cloudflare detection
 - 🚀 **High Performance**: Lightweight Go implementation with minimal dependencies
@@ -50,8 +50,12 @@ Download the latest binary from the [releases page](https://github.com/akhfa/myi
 |----------|-------------|---------------|
 | `/` | IPv4 address only | `text/plain` |
 | `/?format=json` | IPv4 address in JSON format | `application/json` |
+| `/?format=jsonp` | IPv4 address in JSONP format | `application/javascript` |
+| `/?format=jsonp&callback=getip` | IPv4 address in JSONP format with custom callback | `application/javascript` |
 | `/ipv6` | IPv6 address only (404 if not available) | `text/plain` |
 | `/ipv6?format=json` | IPv6 address in JSON format | `application/json` |
+| `/ipv6?format=jsonp` | IPv6 address in JSONP format | `application/javascript` |
+| `/ipv6?format=jsonp&callback=getip` | IPv6 address in JSONP format with custom callback | `application/javascript` |
 | `/info` | Detailed IP information | `text/plain` |
 | `/json` | Comprehensive JSON response | `application/json` |
 | `/headers` | All HTTP headers and IP details | `text/plain` |
@@ -90,6 +94,26 @@ $ curl https://ip.example.com/ipv6
 ```bash
 $ curl https://ip.example.com/ipv6?format=json
 {"ip":"2001:db8::1"}
+```
+
+#### Get IPv4 Address in JSONP Format
+```bash
+$ curl https://ip.example.com/?format=jsonp
+callback({"ip":"203.0.113.1"});
+
+# With custom callback function (requires format=jsonp)
+$ curl https://ip.example.com/?format=jsonp&callback=getip
+getip({"ip":"203.0.113.1"});
+```
+
+#### Get IPv6 Address in JSONP Format
+```bash
+$ curl https://ip.example.com/ipv6?format=jsonp
+callback({"ip":"2001:db8::1"});
+
+# With custom callback function (requires format=jsonp)
+$ curl https://ip.example.com/ipv6?format=jsonp&callback=getip
+getip({"ip":"2001:db8::1"});
 ```
 
 #### Get Detailed Information

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -48,17 +48,17 @@ func sanitizeCallback(callback string) string {
 	if callback == "" {
 		return "callback"
 	}
-	
+
 	// Limit callback length to prevent abuse
 	if len(callback) > 50 {
 		return "callback"
 	}
-	
+
 	// Validate callback contains only safe JavaScript identifier characters
 	if !validCallbackRegex.MatchString(callback) {
 		return "callback"
 	}
-	
+
 	return callback
 }
 
@@ -90,9 +90,9 @@ func IPv4Handler(w http.ResponseWriter, r *http.Request) {
 	// Check if JSONP format is requested (case-insensitive, optimized)
 	if isJSONPFormat(format) {
 		sanitizedCallback := sanitizeCallback(callback)
-		
+
 		w.Header().Set("Content-Type", "application/javascript")
-		
+
 		// Use proper JSON encoding to prevent injection attacks
 		response := map[string]string{"ip": ipv4}
 		jsonBytes, err := json.Marshal(response)
@@ -101,7 +101,7 @@ func IPv4Handler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Failed to encode JSONP response", http.StatusInternalServerError)
 			return
 		}
-		
+
 		fmt.Fprintf(w, "%s(%s);", sanitizedCallback, string(jsonBytes))
 		return
 	}
@@ -152,9 +152,9 @@ func IPv6Handler(w http.ResponseWriter, r *http.Request) {
 	// Check if JSONP format is requested (case-insensitive, optimized)
 	if isJSONPFormat(format) {
 		sanitizedCallback := sanitizeCallback(callback)
-		
+
 		w.Header().Set("Content-Type", "application/javascript")
-		
+
 		// Use proper JSON encoding to prevent injection attacks
 		response := map[string]string{"ip": ipv6}
 		jsonBytes, err := json.Marshal(response)
@@ -163,7 +163,7 @@ func IPv6Handler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Failed to encode JSONP response", http.StatusInternalServerError)
 			return
 		}
-		
+
 		fmt.Fprintf(w, "%s(%s);", sanitizedCallback, string(jsonBytes))
 		return
 	}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 
 	"myip/internal/ip"
 	"myip/internal/models"
@@ -40,15 +39,15 @@ func isJSONPFormat(format string) bool {
 
 // IPv4Handler handles requests for IPv4 addresses only
 // @Summary Get IPv4 address
-// @Description Returns the client's IPv4 address in plain text format, JSON format if format=json, or JSONP format if format=jsonp or callback query parameter is specified (case-insensitive)
+// @Description Returns the client's IPv4 address in plain text format, JSON format if format=json, or JSONP format if format=jsonp is specified (case-insensitive). Callback parameter only works with format=jsonp.
 // @Tags IP Detection
 // @Accept json
 // @Produce plain,json
 // @Param format query string false "Response format (json for JSON response, jsonp for JSONP response)"
-// @Param callback query string false "Callback function name for JSONP response (default: callback)"
+// @Param callback query string false "Callback function name for JSONP response. Only works with format=jsonp. Without format=jsonp, callback parameter is ignored and returns plain text (ipify.org compatible behavior). (default: callback)"
 // @Success 200 {string} string "IPv4 address (plain text)"
 // @Success 200 {object} map[string]string "IP address in JSON format: {\"ip\": \"192.168.1.1\"}"
-// @Success 200 {string} string "IP address in JSONP format: callback({\"ip\": \"192.168.1.1\"})"
+// @Success 200 {string} string "IP address in JSONP format: callback({\"ip\": \"192.168.1.1\"}) or getip({\"ip\": \"192.168.1.1\"}) with custom callback"
 // @Failure 404 {string} string "No IPv4 address found"
 // @Router / [get]
 func IPv4Handler(w http.ResponseWriter, r *http.Request) {
@@ -63,8 +62,8 @@ func IPv4Handler(w http.ResponseWriter, r *http.Request) {
 	format := r.URL.Query().Get("format")
 	callback := r.URL.Query().Get("callback")
 
-	// Check if JSONP format is requested (case-insensitive, optimized) OR callback is provided
-	if isJSONPFormat(format) || (callback != "" && len(strings.TrimSpace(callback)) > 0) {
+	// Check if JSONP format is requested (case-insensitive, optimized)
+	if isJSONPFormat(format) {
 		if callback == "" {
 			callback = "callback"
 		}
@@ -94,15 +93,15 @@ func IPv4Handler(w http.ResponseWriter, r *http.Request) {
 
 // IPv6Handler handles requests for IPv6 addresses only
 // @Summary Get IPv6 address
-// @Description Returns the client's IPv6 address in plain text format, JSON format if format=json, or JSONP format if format=jsonp or callback query parameter is specified (case-insensitive)
+// @Description Returns the client's IPv6 address in plain text format, JSON format if format=json, or JSONP format if format=jsonp is specified (case-insensitive). Callback parameter only works with format=jsonp.
 // @Tags IP Detection
 // @Accept json
 // @Produce plain,json
 // @Param format query string false "Response format (json for JSON response, jsonp for JSONP response)"
-// @Param callback query string false "Callback function name for JSONP response (default: callback)"
+// @Param callback query string false "Callback function name for JSONP response. Only works with format=jsonp. Without format=jsonp, callback parameter is ignored and returns plain text (ipify.org compatible behavior). (default: callback)"
 // @Success 200 {string} string "IPv6 address (plain text)"
 // @Success 200 {object} map[string]string "IP address in JSON format: {\"ip\": \"2001:db8::1\"}"
-// @Success 200 {string} string "IP address in JSONP format: callback({\"ip\": \"2001:db8::1\"})"
+// @Success 200 {string} string "IP address in JSONP format: callback({\"ip\": \"2001:db8::1\"}) or getip({\"ip\": \"2001:db8::1\"}) with custom callback"
 // @Failure 404 {string} string "No IPv6 address found"
 // @Router /ipv6 [get]
 func IPv6Handler(w http.ResponseWriter, r *http.Request) {
@@ -117,8 +116,8 @@ func IPv6Handler(w http.ResponseWriter, r *http.Request) {
 	format := r.URL.Query().Get("format")
 	callback := r.URL.Query().Get("callback")
 
-	// Check if JSONP format is requested (case-insensitive, optimized) OR callback is provided
-	if isJSONPFormat(format) || (callback != "" && len(strings.TrimSpace(callback)) > 0) {
+	// Check if JSONP format is requested (case-insensitive, optimized)
+	if isJSONPFormat(format) {
 		if callback == "" {
 			callback = "callback"
 		}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -1444,14 +1444,14 @@ func TestJSONPEdgeCases(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			
+
 			var handler http.HandlerFunc
 			if test.endpoint == "/ipv6" {
 				handler = IPv6Handler
 			} else {
 				handler = IPv4Handler
 			}
-			
+
 			handler.ServeHTTP(rr, req)
 
 			if status := rr.Code; status != test.expectedCode {
@@ -1585,7 +1585,7 @@ func TestJSONPCallbackValidation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			result := sanitizeCallback(test.callback)
 			if result != test.expectedCallback {
-				t.Errorf("sanitizeCallback(%q) = %q, expected %q: %s", 
+				t.Errorf("sanitizeCallback(%q) = %q, expected %q: %s",
 					test.callback, result, test.expectedCallback, test.description)
 			}
 		})
@@ -1649,14 +1649,14 @@ func TestJSONPWithDifferentIPTypes(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			
+
 			var handler http.HandlerFunc
 			if test.endpoint == "/ipv6" {
 				handler = IPv6Handler
 			} else {
 				handler = IPv4Handler
 			}
-			
+
 			handler.ServeHTTP(rr, req)
 
 			if status := rr.Code; status != http.StatusOK {
@@ -1684,7 +1684,7 @@ func TestJSONPWithDifferentIPTypes(t *testing.T) {
 			start := strings.Index(response, "(")
 			end := strings.LastIndex(response, ");")
 			jsonPart := response[start+1 : end]
-			
+
 			var jsonObj map[string]string
 			err := json.Unmarshal([]byte(jsonPart), &jsonObj)
 			if err != nil {


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added JSONP format support for IPv4 and IPv6 handlers

- Implemented callback parameter handling with ipify.org compatibility

- Added comprehensive test coverage for JSONP functionality

- Updated API documentation and README with JSONP examples


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Request Handler"] -- "format=jsonp" --> B["JSONP Format Check"]
  B -- "valid" --> C["Callback Processing"]
  C -- "default/custom" --> D["JSONP Response"]
  A -- "callback without format" --> E["Plain Text Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handlers.go</strong><dd><code>Add JSONP format support to IP handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/handlers/handlers.go

<ul><li>Added <code>isJSONPFormat</code> function for case-insensitive JSONP format <br>detection<br> <li> Modified IPv4Handler and IPv6Handler to support JSONP format and <br>callback parameter<br> <li> Updated API documentation with JSONP format and callback parameter <br>descriptions<br> <li> Added proper content-type headers for JSONP responses</ul>


</details>


  </td>
  <td><a href="https://github.com/akhfa/myip/pull/24/files#diff-0043929b176a6dd563ab4f5b393f095138a1200b3a22647ca5aa8e112579c80a">+52/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handlers_test.go</strong><dd><code>Add comprehensive JSONP format tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/handlers/handlers_test.go

<ul><li>Added <code>TestIsJSONPFormat</code> function to test JSONP format detection<br> <li> Added comprehensive test suites for IPv4 and IPv6 JSONP functionality<br> <li> Added tests for callback parameter behavior without format=jsonp <br>(ipify.org compatibility)<br> <li> Added IPv6-specific JSONP tests with various callback scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/akhfa/myip/pull/24/files#diff-ef220a63cc346acf15844229fdca3197371fc38b594b993251e191b47ff6d7ed">+421/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation with JSONP format examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated feature description to include JSONP format support<br> <li> Added JSONP endpoint examples to API endpoints table<br> <li> Added curl examples for JSONP format with default and custom callbacks<br> <li> Updated multi-protocol support description to include JSONP</ul>


</details>


  </td>
  <td><a href="https://github.com/akhfa/myip/pull/24/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+25/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

